### PR TITLE
Slight change to how favicon.ico is fetched

### DIFF
--- a/htdocs/application/views/defaults/header.php
+++ b/htdocs/application/views/defaults/header.php
@@ -12,6 +12,7 @@ $page_title .= $this->config->item('site_name');
 	<head>
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 		<title><?php echo $page_title; ?></title>
+		<link rel="shortcut icon" href="<?php echo base_url() . 'favicon.ico'; ?>" />
 <?php
 
 //Carabiner


### PR DESCRIPTION
Just a small change to a view to pull the correct favicon.ico file.

This ensures that the nifty green Stikked favicon will be pulled
regardless of whether Stikked lives at the document root (htdocs) or a
subdirectory (htdocs/stikked).
