### PR TITLE
Adjusted pastes for trending updates to be more database agnostic

### DIFF
--- a/htdocs/application/models/pastes.php
+++ b/htdocs/application/models/pastes.php
@@ -293,14 +293,20 @@ class Pastes extends CI_Model
 		}
 
 		// hits
+		$hits_where = array(
+			'paste_id' => $pid,
+		);
 		$hits_data = array(
 			'paste_id' => $pid,
 			'ip_address' => $this->input->ip_address() ,
 			'created' => mktime() ,
 		);
-		$insert_query = $this->db->insert_string('trending', $hits_data);
-		$insert_query = str_replace('INSERT INTO', 'INSERT IGNORE INTO', $insert_query);
-		$this->db->query($insert_query);
+		$update_query = $this->db->update_string('trending', $hits_data, $hits_where);
+		$this->db->query($update_query);
+		if ($this->db->affected_rows() == 0) {
+			$insert_query = $this->db->insert_string('trending', $hits_data);
+			$this->db->query($insert_query);
+		}
 		
 		if (mktime() > (60 + $data['hits_updated'])) 
 		{


### PR DESCRIPTION
I adjusted the pastes.php to include more database agnostic functionality so that it does not depend on non-standard MySQL-specific SQL statements by changing the trending update portion to update, check for affected rows, and insert if nothing updated. 

This allows Stikked to be more database agnostic, remain optimal, and work with PostgreSQL and other databases.
