### PR TITLE
add default robots.txt

### DIFF
--- a/htdocs/robots.txt
+++ b/htdocs/robots.txt
@@ -1,0 +1,3 @@
+# http://www.robotstxt.org/
+User-agent: *
+Disallow: /


### PR DESCRIPTION
add default robots.txt to drive spammers away from public pastebin installations.

this is just in hope that the won't spam you because your site is not indexed, and they may stop spamming you.

currently i don't see stikked having any robots.txt file nor using any html meta tags to control pastebin indexing
