### PR TITLE
Reflect new app URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here are some features:
 * Anti-Spam features
 * Themes support
 * Multilanguage support
-* The awesome Team BlueRidge made an [Android app](https://play.google.com/store/apps/details?id=org.teamblueridge.paste)
+* The awesome Team BlueRidge made an [Android app](https://play.google.com/store/apps/details?id=org.teamblueridge.pasteit)
 * Command line tool to upload paste to Stikked based pastebins: [Stikkit](https://github.com/benapetr/stikkit)
 * And many more. View [this review](http://maketecheasier.com/run-your-own-pastebin-with-stikked/2013/01/11) 
 


### PR DESCRIPTION
Due to some Play Store-related issues, Team BlueRidge now has a new URL for the app

Sorry for the inconvenience, but if you could merge this, that'd be awesome!
