### PR TITLE
Move 'Plain Text' to top in language list.

### DIFF
--- a/htdocs/application/config/geshi_languages.php
+++ b/htdocs/application/config/geshi_languages.php
@@ -9,6 +9,7 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
 
 //geshi languages
 $config['geshi_languages'] = array(
+	'text' => 'Plain Text',
 	'html5' => 'HTML5',
 	'css' => 'CSS',
 	'javascript' => 'JavaScript',
@@ -25,7 +26,7 @@ $config['geshi_languages'] = array(
 	'latex' => 'LaTeX',
 	'sql' => 'SQL',
 	'xml' => 'XML',
-	'text' => 'Plain Text',
+	'' => '',  // separator
 	'4cs' => '4CS',
 	'6502acme' => 'MOS 6502',
 	'6502kickass' => 'MOS 6502 Kick Assembler',

--- a/htdocs/application/models/languages.php
+++ b/htdocs/application/models/languages.php
@@ -30,11 +30,13 @@ class Languages extends CI_Model
 		$data = array();
 		foreach ($this->geshi_languages as $key => $value) 
 		{
-			$data[$key] = $value;
-			
-			if ($key == 'text') 
+			if ($key == '')
 			{
 				$data["0"] = "-----------------";
+			}
+			else
+			{
+				$data[$key] = $value;
 			}
 		}
 		return $data;


### PR DESCRIPTION
I often want to chose a language by clicking the dropdown and then starting to type (e.g. "Pyth..."), but for languages in the top "quick-list" this won't work because the default (plaintext) is not the first item.

This moves it to top instead, and uses an empty item for the separator line.
