### PR TITLE
Burn on read cron delete fix + Stikkedizr theme fix

### DIFF
--- a/htdocs/application/models/pastes.php
+++ b/htdocs/application/models/pastes.php
@@ -698,7 +698,7 @@ class Pastes extends CI_Model
 		{
 			$stamp = $row['expire'];
 			
-			if ($now > $stamp) 
+			if ($now > $stamp AND $stamp != 0) 
 			{
 				$this->delete_paste($row['pid']);
 			}

--- a/htdocs/themes/stikkedizr/views/defaults/header.php
+++ b/htdocs/themes/stikkedizr/views/defaults/header.php
@@ -10,6 +10,7 @@ $page_title .= $this->config->item('site_name');
 <html lang="en">
 	<head>
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title><?php echo $page_title; ?></title>
 <?php
 


### PR DESCRIPTION
Cron used to delete all pastes with toexpire set to 1. Burn on read
pastes had this param set by default to 1 also, so they get removed even
if unreaded.

Stikkedizr theme updated for dynamic width for different devices (which theme will be next? ;))