### PR TITLE
Fixed reCaptcha not loaded on SSL site

### DIFF
--- a/htdocs/application/helpers/recaptcha_helper.php
+++ b/htdocs/application/helpers/recaptcha_helper.php
@@ -35,7 +35,7 @@
 /**
  * The reCAPTCHA server URL's
  */
-define("RECAPTCHA_API_SERVER", "http://www.google.com/recaptcha/api");
+define("RECAPTCHA_API_SERVER", "//www.google.com/recaptcha/api");
 define("RECAPTCHA_API_SECURE_SERVER", "https://www.google.com/recaptcha/api");
 define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
 
@@ -241,7 +241,7 @@ function recaptcha_mailhide_url($pubkey, $privkey, $email) {
 	$ky = pack('H*', $privkey);
 	$cryptmail = _recaptcha_aes_encrypt ($email, $ky);
 	
-	return "http://www.google.com/recaptcha/mailhide/d?k=" . $pubkey . "&c=" . _recaptcha_mailhide_urlbase64 ($cryptmail);
+	return "https://www.google.com/recaptcha/mailhide/d?k=" . $pubkey . "&c=" . _recaptcha_mailhide_urlbase64 ($cryptmail);
 }
 
 /**


### PR DESCRIPTION
Fixed reCaptcha bug which was causing reCaptcha to not be loaded if site is loaded over SSL due to mixed content. Link is now universal. This is small thing, but I hope to be able to contribute more.

EDIT: Just noticed that there is actualy check if site is SSL, however it doesn't worked for me.
Better approach is just to let the browser decide with only // instead of http / https