### PR TITLE
Added support for Goo.gl and Bit.ly URL shortening API-s

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,3 +33,4 @@
 * Abbas A. Elmas https://github.com/abbaselmas (Intense testing and making valuable suggestions)
 * Sebastian Korotkiewicz http://git.itunix.eu/git/cleanwhite.git/ (CleanWhite theme)
 * Franklyn Tackitt https://github.com/kageurufu (Fixed bug with db_prefix config value)
+* Aleksandar Puharic https://github.com/xZero707/  (New URL shortening API-s Goo.gl and Bit.ly, several fixes)

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -1,6 +1,6 @@
 RewriteEngine on
 #RewriteBase /
-RewriteCond $1 !^(index\.php|static|favicon\.ico|robots\.txt|sitemap.xml|google(.+)\.html)
+RewriteCond $1 !^(index\.php|static|favicon\.ico|robots\.txt|sitemap.xml|upgrade|google(.+)\.html)
 RewriteRule ^(.*)$ index.php?/$1 [QSA,L]
 
 SetOutputFilter DEFLATE

--- a/htdocs/application/config/stikked.php.dist
+++ b/htdocs/application/config/stikked.php.dist
@@ -66,24 +66,63 @@ $config['cron_key'] = '';
 /**
  * url shortener config
  *
- * If yourls_url is set, yourls is used instead of gw.gd
- *
+ * url_shortening_use:
+ *    - Enables specific url shortening engine or disables them all
+ *    - Valid values:
+ *           @string yourls
+ *           @string gwgd
+ *           @string googl
+ *           @string bitly 
+ *           @string random - Randomly chose any of upper API-s !WARNING! May be slow! For maximum performanse, it's recommended to either set all API keys or use random_url_engines to list working engines.
+ *           @string none - same as off
+ * 
+ * random_url_engines:
+ *    - This variable sets list of APIs to be considered for usage if url_shortening_use is set to 'random'
+ *      To consider all API-s, either leave it empty (as empty array or string) or type all apis available (yourls,gwgd,googl,bitly)
+ *      be aware that considering all the APIs is not recommended because program will test them all, and that affects speed.
+ *      This will greatly improve performance of 'random' mode if listed are only valid, filled APIs.
+ *      Accepted inputs:
+ *           @array array('use this', 'and this', 'and this of course')
+ *           @string 'use this,and this,and this of course'
+ *      - If input is @string it must be comma delimited, otherwise will be ignored.
+ *      - Script will accept minimum of 2 APIs, ignored otherwise
+ *      - Only alphanumeric characters and "." are allowed. Everything else is filtered out.
+ * 
+ * -------------------------------------------------------------------------------------------------------------
  * yourls_url: Your own instance of yourls URL-shortener (Download: http://yourls.org/)
  * Example: http://example.com/yourls/
  *
  * yourls_signature: Your signature, used to authenticate API requests.
  * You can find your signature under http://your-yourls-installation.com/admin/tools.php
  *
- * OR
- *
  * gwgd_url: Your own instance of the gw.gd URL-shortener (Download: https://github.com/neofutur/gwgd)
  * Default: http://gw.gd/
  *
+ * googl_url_api: URL shortening service provided by Google Inc. (API: http://code.google.com/apis/console/) 
+ * Usage: Your API key
+ * 
+ * bitly_url_api: Famous URL shortening service (API: http://dev.bitly.com/get_started.html)
+ * Usage: Your API key
+ * 
 **/
+$config['url_shortening_use'] = 'off';
+$config['random_url_engines'] = 'googl,bitly'; // Used only in random mode, read comment above for more info
+
+
+// Yourls
 $config['yourls_url'] = '';
 $config['yourls_signature'] = '';
+
+// gwgd_url
 $config['gwgd_url'] = '';
 $config['shorturl_selected'] = false;
+
+// goo.gl API key
+$config['googl_url_api'] = '';
+// Bit.ly API key
+$config['bitly_url_api'] = '';
+
+
 
 /**
  * Credentials for the backup URL
@@ -207,32 +246,223 @@ $config['displayurl_override'] = '';
  *
  *
 **/
-$config['nouns'] = array('Hornbill', 'Elephant', 'Bison', 'Lion', 'Camel', 'Sheep',
-'Monkey', 'Prairie Dog', 'Plover', 'Tapir', 'Capybara', 'Cheetah', 'Flamingo', 'Peccary', 'Eider',	'Porcupine', 'Pelican', 'Dove', 'Crane', 'Tortoise', 'Agouti',
-'Tamarin', 'Pheasant', 'Owl', 'Gibbon', 'Goose', 'Baboon', 'Hamerkop', 'Zebra',
-'Macaw', 'Gibbon', 'Madrill', 'Wolf', 'Stork', 'Armadillo', 'Ostrich', 'Marmoset',
-'Lizard', 'Panda', 'Giraffe', 'Cassowary', 'Kangaroo', 'Gorilla', 'Pheasant',
-'Finch', 'Duck', 'Matamata', 'Teal', 'Macaque', 'Goat', 'Lechwe', 'Ibis', 'Parrot',
-'Parakeet', 'Bongo', 'Pudu', 'Echidna', 'Lemur', 'Bat', 'Curlew', 'Terrapin',
-'Peafowl', 'Duck', 'Owl', 'Parakeet', 'Meerkat', 'Tern', 'Wigeon', 'Pintail',
-'Meerkat', 'Motmot', 'Motmot', 'Shama', 'Dormouse', 'Horse', 'Rhinoceros', 'Sloth',
- 'Mousedeer', 'Treeshrew', 'Bushbaby', 'Guinea Pig', 'Agouti', 'Water Vole', 'Hog',
-'Pig', 'Anoa', 'Octupus', 'Butterfly', 'Cat', 'Kitten', 'Coyote', 'Crocodile',
-'Cockroach', 'Crow', 'Bird', 'Dolphin', 'Earthworm', 'Frog', 'Hamster', 'Hedgehog',
-'Hog', 'Human', 'Hummingbird', 'Iguana', 'Leech', 'Leopard', ' Marten',
-'Mockingbird', 'Mockingjay', 'Mosquito', 'Moth', 'Partdridge', 'Bee', 'Penguin');
+$config['nouns'] = array (
+  0 => 'Hornbill',
+  1 => 'Elephant',
+  2 => 'Bison',
+  3 => 'Lion',
+  4 => 'Camel',
+  5 => 'Sheep',
+  6 => 'Monkey',
+  7 => 'Prairie Dog',
+  8 => 'Plover',
+  9 => 'Tapir',
+  10 => 'Capybara',
+  11 => 'Cheetah',
+  12 => 'Flamingo',
+  13 => 'Peccary',
+  14 => 'Eider',
+  15 => 'Porcupine',
+  16 => 'Pelican',
+  17 => 'Dove',
+  18 => 'Crane',
+  19 => 'Tortoise',
+  20 => 'Agouti',
+  21 => 'Tamarin',
+  22 => 'Pheasant',
+  23 => 'Owl',
+  24 => 'Gibbon',
+  25 => 'Goose',
+  26 => 'Baboon',
+  27 => 'Hamerkop',
+  28 => 'Zebra',
+  29 => 'Macaw',
+  30 => 'Gibbon',
+  31 => 'Madrill',
+  32 => 'Wolf',
+  33 => 'Stork',
+  34 => 'Armadillo',
+  35 => 'Ostrich',
+  36 => 'Marmoset',
+  37 => 'Lizard',
+  38 => 'Panda',
+  39 => 'Giraffe',
+  40 => 'Cassowary',
+  41 => 'Kangaroo',
+  42 => 'Gorilla',
+  43 => 'Pheasant',
+  44 => 'Finch',
+  45 => 'Duck',
+  46 => 'Matamata',
+  47 => 'Teal',
+  48 => 'Macaque',
+  49 => 'Goat',
+  50 => 'Lechwe',
+  51 => 'Ibis',
+  52 => 'Parrot',
+  53 => 'Parakeet',
+  54 => 'Bongo',
+  55 => 'Pudu',
+  56 => 'Echidna',
+  57 => 'Lemur',
+  58 => 'Bat',
+  59 => 'Curlew',
+  60 => 'Terrapin',
+  61 => 'Peafowl',
+  62 => 'Duck',
+  63 => 'Owl',
+  64 => 'Parakeet',
+  65 => 'Meerkat',
+  66 => 'Tern',
+  67 => 'Wigeon',
+  68 => 'Pintail',
+  69 => 'Meerkat',
+  70 => 'Motmot',
+  71 => 'Motmot',
+  72 => 'Shama',
+  73 => 'Dormouse',
+  74 => 'Horse',
+  75 => 'Rhinoceros',
+  76 => 'Sloth',
+  77 => 'Mousedeer',
+  78 => 'Treeshrew',
+  79 => 'Bushbaby',
+  80 => 'Guinea Pig',
+  81 => 'Agouti',
+  82 => 'Water Vole',
+  83 => 'Hog',
+  84 => 'Pig',
+  85 => 'Anoa',
+  86 => 'Octupus',
+  87 => 'Butterfly',
+  88 => 'Cat',
+  89 => 'Kitten',
+  90 => 'Coyote',
+  91 => 'Crocodile',
+  92 => 'Cockroach',
+  93 => 'Crow',
+  94 => 'Bird',
+  95 => 'Dolphin',
+  96 => 'Earthworm',
+  97 => 'Frog',
+  98 => 'Hamster',
+  99 => 'Hedgehog',
+  100 => 'Hog',
+  101 => 'Human',
+  102 => 'Hummingbird',
+  103 => 'Iguana',
+  104 => 'Leech',
+  105 => 'Leopard',
+  106 => ' Marten',
+  107 => 'Mockingbird',
+  108 => 'Mockingjay',
+  109 => 'Mosquito',
+  110 => 'Moth',
+  111 => 'Partdridge',
+  112 => 'Bee',
+  113 => 'Penguin',
+);
 
-$config['adjectives'] = array('Ample', 'Mature', 'Bulky', 'Burly', 'Capacious',
-'Colossal', 'Commodious', 'Thundering', 'Mammoth', 'Mungo', 'Voluminous',
-'Walloping', 'Tiny', 'Baby', 'Bitty', 'Diminutive', 'Little', 'Paltry', 'Scanty',
-'Trivial', 'Scribby', 'Blush', 'Tinct', 'Colorant', 'Aqua', 'Beige', 'Bistre',
-'Buff', 'Bistre', 'Chartreuse', 'Chocolate', 'Cobalt', 'Coral', 'Cream', 'Crimson',
-'Denim', 'Emerald', 'Gray', 'Gamboge', 'Ivory', 'Mustard', 'Silly', 'Perl',
-'Whipped', 'Violet', 'Harmless', 'Gentle', 'Innocent', 'Reliable', 'Unreliable',
-'Soft', 'Toxic', 'Anorexic', 'Beefy', 'Sexy', 'Morose', 'Rude', 'Ungracious',
-'Abrupt', 'Gracious', 'Queen', 'Cute', 'Edgy', 'Insensitive', 'Round', 'Sharp',
-'Gruff', 'Subtle', 'Crippled', 'Eratic', 'Social', 'Jittery', 'Sole', 'Unique',
-'Botched', 'Tacky', 'Sludgy', 'Stained', 'Wet', 'Soiled', 'Big', 'Small', 'Sloppy',
-'Smelly', 'Funky', 'Putrid', 'Melodic', 'Corrupt', 'Lousy', 'Fiery', 'Red',
-'Sweet', 'Hot', 'Scorching', 'Sweltering', 'Torrid', 'Obese', 'Speedy', 'Flying',
-'Idiotic', 'Chunky');
+$config['adjectives'] = array (
+  0 => 'Ample',
+  1 => 'Mature',
+  2 => 'Bulky',
+  3 => 'Burly',
+  4 => 'Capacious',
+  5 => 'Colossal',
+  6 => 'Commodious',
+  7 => 'Thundering',
+  8 => 'Mammoth',
+  9 => 'Mungo',
+  10 => 'Voluminous',
+  11 => 'Walloping',
+  12 => 'Tiny',
+  13 => 'Baby',
+  14 => 'Bitty',
+  15 => 'Diminutive',
+  16 => 'Little',
+  17 => 'Paltry',
+  18 => 'Scanty',
+  19 => 'Trivial',
+  20 => 'Scribby',
+  21 => 'Blush',
+  22 => 'Tinct',
+  23 => 'Colorant',
+  24 => 'Aqua',
+  25 => 'Beige',
+  26 => 'Bistre',
+  27 => 'Buff',
+  28 => 'Bistre',
+  29 => 'Chartreuse',
+  30 => 'Chocolate',
+  31 => 'Cobalt',
+  32 => 'Coral',
+  33 => 'Cream',
+  34 => 'Crimson',
+  35 => 'Denim',
+  36 => 'Emerald',
+  37 => 'Gray',
+  38 => 'Gamboge',
+  39 => 'Ivory',
+  40 => 'Mustard',
+  41 => 'Silly',
+  42 => 'Perl',
+  43 => 'Whipped',
+  44 => 'Violet',
+  45 => 'Harmless',
+  46 => 'Gentle',
+  47 => 'Innocent',
+  48 => 'Reliable',
+  49 => 'Unreliable',
+  50 => 'Soft',
+  51 => 'Toxic',
+  52 => 'Anorexic',
+  53 => 'Beefy',
+  54 => 'Sexy',
+  55 => 'Morose',
+  56 => 'Rude',
+  57 => 'Ungracious',
+  58 => 'Abrupt',
+  59 => 'Gracious',
+  60 => 'Queen',
+  61 => 'Cute',
+  62 => 'Edgy',
+  63 => 'Insensitive',
+  64 => 'Round',
+  65 => 'Sharp',
+  66 => 'Gruff',
+  67 => 'Subtle',
+  68 => 'Crippled',
+  69 => 'Eratic',
+  70 => 'Social',
+  71 => 'Jittery',
+  72 => 'Sole',
+  73 => 'Unique',
+  74 => 'Botched',
+  75 => 'Tacky',
+  76 => 'Sludgy',
+  77 => 'Stained',
+  78 => 'Wet',
+  79 => 'Soiled',
+  80 => 'Big',
+  81 => 'Small',
+  82 => 'Sloppy',
+  83 => 'Smelly',
+  84 => 'Funky',
+  85 => 'Putrid',
+  86 => 'Melodic',
+  87 => 'Corrupt',
+  88 => 'Lousy',
+  89 => 'Fiery',
+  90 => 'Red',
+  91 => 'Sweet',
+  92 => 'Hot',
+  93 => 'Scorching',
+  94 => 'Sweltering',
+  95 => 'Torrid',
+  96 => 'Obese',
+  97 => 'Speedy',
+  98 => 'Flying',
+  99 => 'Idiotic',
+  100 => 'Chunky',
+);

--- a/htdocs/application/models/pastes.php
+++ b/htdocs/application/models/pastes.php
@@ -925,6 +925,7 @@ class Pastes extends CI_Model
 		$this->load->library('process');
 		$this->db->order_by('id', 'RANDOM');
 		$this->db->limit(1);
+                $this->db->where('private', '0');
 		$query = $this->db->get('pastes');
 		
 		if ($query->num_rows() > 0) 

--- a/htdocs/themes/snowkat/css/main.css
+++ b/htdocs/themes/snowkat/css/main.css
@@ -273,7 +273,7 @@ h4 {
 }
 
 .form_wrapper button {
-	opacity; 1;
+	opacity: 1;
 	padding: 4px 12px;
 	border: 1px solid #fff;
 	color: #333;

--- a/htdocs/upgrade/.htaccess
+++ b/htdocs/upgrade/.htaccess
@@ -1,0 +1,4 @@
+<Files "upgrade_schema.ugs">
+Order Allow,Deny
+Deny from all
+</Files>

--- a/htdocs/upgrade/index.php
+++ b/htdocs/upgrade/index.php
@@ -1,0 +1,146 @@
+<?PHP
+/**
+* Class and Function List:
+* Function list:
+* Classes list:
+*/
+define("upgradeMode", true);
+require "upconf.php"; // Load configuration file with upgrade  settings
+
+$status = "";
+
+if (!$locked) 
+{
+	$title = "Upgrade";
+	$message = " This upgrade is only needed if you migrate from version lower than 0.9.1.<br/>";
+	$message.= "<span class='warning'>Warning: All custom code will be erased!</span><br/>";
+	$message.= "Do you want to upgrade? <a href='{$URL}?auth={$authCode}'>Yes</a> | <a href='../'>No</a>";
+}
+else
+{
+	$title = "<span class='error'>Upgrade Locked</span>";
+	$message = "Your upgrade directory is locked, unlock it by deleting \"lock\" file.";
+}
+
+if (isset($_GET['status'])) 
+{
+	$uStatus = preg_replace("/[^a-zA-Z0-9.\/]+/", "", $_GET['status']);
+	$uSubject = ((isset($_GET['subject'])) ? preg_replace("/[^a-zA-Z0-9.\/]+/", "", $_GET['status']) : "application/config/stikked.php");
+	switch ($uStatus) 
+	{
+	case "locked":
+		$title = "<span class='error'>Upgrade Locked</span>";
+		$message = "Your upgrade directory is locked, unlock it by deleting \"lock\" file.";
+	break;
+	case "missingTarget":
+	case "missingUgs":
+		$title = "<span class='error'>Upgrade Failed</span>";
+		$message = "Your" . (($uStatus == "missingTarget") ? " configuration file <i>{$targetMain}</i>" : " upgrade schema file <i>{$upgradeSchema}</i>") . " is missing. Check it and try again.";
+	break;
+	case "lockFailed":
+		$title = "<span class='error'>Security risk: Lock failed</span>";
+		$message = "Locking \"upgrade\" directory failed, please, remove it manualy, otherwise, unlocked, it represents security risk.<br/>";
+		$message.= "<span class='success'>However, update was successful.</span>";
+	break;
+	case "success":
+		$title = "<span class='success'>Upgrade succeed</span>";
+		$message = "You're ready to go. ";
+		$message = "<< <a href='../'>Click here to go to your upgraded Stikked site.</a>";
+	break;
+	case "AuthFailed":
+		$title = "<span class='error'>Access denied</span>";
+		$message = "You cannot access {$URL} file directly.";
+	break;
+	case "AuthFailed-config":
+		$title = "<span class='error'>Access denied</span>";
+		$message = "You cannot access upconf.php file directly.";
+	break;
+	case "failed":
+		$title = "<span class='error'>Upgrade failed</span>";
+		$message = "Upgrade has failed. <br/>Your configuration <i>{$targetMain}</i> file must be writtable (chmod 777).";
+	break;
+	default:
+	break;
+	}
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Upgrade <?PHP echo $status; ?></title>
+
+        <script type='text/javascript'>
+            history.pushState(null, null, window.location.pathname);
+        </script>
+
+        <style type="text/css">
+
+            ::selection{ background-color: #E13300; color: white; }
+            ::moz-selection{ background-color: #E13300; color: white; }
+            ::webkit-selection{ background-color: #E13300; color: white; }
+
+            body {
+                background-color: #fff;
+                margin: 40px;
+                font: 13px/20px normal Helvetica, Arial, sans-serif;
+                color: #4F5155;
+            }
+
+            a {
+                color: #003399;
+                background-color: transparent;
+                font-weight: normal;
+            }
+
+            h1 {
+                color: #444;
+                background-color: transparent;
+                border-bottom: 1px solid #D0D0D0;
+                font-size: 19px;
+                font-weight: normal;
+                margin: 0 0 14px 0;
+                padding: 14px 15px 10px 15px;
+            }
+
+            code {
+                font-family: Consolas, Monaco, Courier New, Courier, monospace;
+                font-size: 12px;
+                background-color: #f9f9f9;
+                border: 1px solid #D0D0D0;
+                color: #002166;
+                display: block;
+                margin: 14px 0 14px 0;
+                padding: 12px 10px 12px 10px;
+            }
+
+            #container {
+                margin: 10px;
+                border: 1px solid #D0D0D0;
+                -webkit-box-shadow: 0 0 8px #D0D0D0;
+            }
+
+            p {
+                margin: 12px 15px 12px 15px;
+            }
+
+            .error {
+                color: #FF0000;
+            }
+
+            .warning {
+                color: orangered;
+            }
+
+            .success {
+                color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="container">
+            <h1><?PHP echo $title; ?></h1>
+            <?PHP echo $message; ?>
+        </div>
+    </body>
+</html>

--- a/htdocs/upgrade/index.php
+++ b/htdocs/upgrade/index.php
@@ -12,7 +12,7 @@ $status = "";
 if (!$locked) 
 {
 	$title = "Upgrade";
-	$message = " This upgrade is only needed if you migrate from version lower than 0.9.1.<br/>";
+	$message = " This upgrade is only needed if you migrate from version lower than 0.9.2.<br/>";
 	$message.= "<span class='warning'>Warning: All custom code will be erased!</span><br/>";
 	$message.= "Do you want to upgrade? <a href='{$URL}?auth={$authCode}'>Yes</a> | <a href='../'>No</a>";
 }

--- a/htdocs/upgrade/upconf.php
+++ b/htdocs/upgrade/upconf.php
@@ -1,0 +1,27 @@
+<?php
+/**
+* Class and Function List:
+* Function list:
+* Classes list:
+*/
+
+if (!defined("upgradeMode")) 
+{
+	header("location: index.php?status=AuthFailed");
+	exit;
+}
+$URL = "upgrade.php";
+$targetMain = "../application/config/stikked.php";
+$upgradeSchema = "upgrade_schema.ugs";
+$authCode = "e4434b336503842424d7ffd0628d36f88e2270fbe9c6a7bc46cf5e3510bfd8d5";
+
+// Lock check
+
+if (!file_exists("lock")) 
+{
+	$locked = false;
+}
+else
+{
+	$locked = true;
+}

--- a/htdocs/upgrade/upgrade.php
+++ b/htdocs/upgrade/upgrade.php
@@ -2,7 +2,8 @@
 /**
  * Patch for application/config/stikked.php
  * @since 0.9.2
- * New version, new features! Your stikked.php need to be upgraded, and running this script will do so.
+ * New
+ *  version, new features! Your stikked.php need to be upgraded, and running this script will do so.
  * No worry, your's settings will be left intact, just few things added.
  *
  * !WARNING!

--- a/htdocs/upgrade/upgrade.php
+++ b/htdocs/upgrade/upgrade.php
@@ -1,13 +1,7 @@
 <?php
 /**
- * Class and Function List:
- * Function list:
- * - parseOption()
- * Classes list:
- */
-/**
  * Patch for application/config/stikked.php
- * @since 0.9.1
+ * @since 0.9.2
  * New version, new features! Your stikked.php need to be upgraded, and running this script will do so.
  * No worry, your's settings will be left intact, just few things added.
  *

--- a/htdocs/upgrade/upgrade.php
+++ b/htdocs/upgrade/upgrade.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Class and Function List:
+ * Function list:
+ * - parseOption()
+ * Classes list:
+ */
+/**
+ * Patch for application/config/stikked.php
+ * @since 0.9.1
+ * New version, new features! Your stikked.php need to be upgraded, and running this script will do so.
+ * No worry, your's settings will be left intact, just few things added.
+ *
+ * !WARNING!
+ * Any custom code will be erased. Make backup of whole installation first.
+ */
+define("upgradeMode", true);
+require "upconf.php"; // Load configuration file with upgrade  settings
+
+
+if (!isset($_GET['auth'])) 
+{
+	header("location: index.php?status=AuthFailed");
+	exit;
+}
+else 
+if ($_GET['auth'] !== $authCode) 
+{
+	header("location: index.php?status=AuthFailed");
+	exit;
+}
+
+if ($locked) 
+{
+	header("location: index.php?status=locked");
+	exit;
+}
+define("BASEPATH", true);
+
+if (!file_exists($targetMain)) 
+{
+	header("location: index.php?status=missingTarget");
+	exit;
+}
+else 
+if (!file_exists($upgradeSchema)) 
+{
+	die("Your {$upgradeSchema} doesn't exist! Upgrade has failed.");
+	header("location: index.php?status=missingUgs");
+	exit;
+}
+require ($targetMain);
+$upgradeSchema = file_get_contents($upgradeSchema);
+/**
+ * Detects type of given data and return them in appropriate string form
+ * @author xZero <xzero@elite7hackers.net>
+ * @param mixed $d
+ * @return string result
+ */
+
+function parseOption($d) 
+{
+	
+	if (is_bool($d)) 
+	{
+		return ($d) ? 'true' : 'false';
+	}
+	else 
+	if (is_numeric($d)) 
+	{
+		return $d;
+	}
+	else 
+	if (is_string($d)) 
+	{
+		return "'{$d}'";
+	}
+	else 
+	if (is_array($d)) 
+	{
+		return var_export($d, true);
+	}
+	else
+	{
+		return "''";
+	}
+}
+$FIND = array(
+	"{INS->SITE_NAME}",
+	"{INS->DB_HOSTNAME}",
+	"{INS->DB_DATABASE}",
+	"{INS->DB_USERNAME}",
+	"{INS->DB_PASSWORD}",
+	"{INS->DB_PREFIX}",
+	"{INS->THEME}",
+	"{INS->COMBINE_ASSETS}",
+	"{INS->CRON_KEY}",
+	"{INS->URL_SHORTENING_NEW#1}",
+	"{INS->YOURLS_URL}",
+	"{INS->YOURLS_SIGNATURE}",
+	"{INS->GWGD_URL}",
+	"{INS->SHORTURL_SELECTED}",
+	"{INS->URL_SHORTENING_NEW#2}",
+	"{INS->BACKUP_USER}",
+	"{INS->BACKUP_PASS}",
+	"{INS->PER_PAGE}",
+	"{INS->APIKEY}",
+	"{INS->PRIVATE_ONLY}",
+	"{INS->ENABLE_CAPTCHA}",
+	"{INS->PUBLICKEY}",
+	"{INS->PRIVATEKEY}",
+	"{INS->DISABLEAPI}",
+	"{INS->DISABLEKEEPFOREVER}",
+	"{INS->BLOCKEDWORDS}",
+	"{INS->DISABLE_SHORTURL}",
+	"{INS->DISALLOW_SEARCH_ENGINES}",
+	"{INS->SPAMADMIN_USER}",
+	"{INS->SPAMADMIN_PASS}",
+	"{INS->DEFAULT_EXPIRATION}",
+	"{INS->DEFAULT_LANGUAGE}",
+	"{INS->UNKNOWN_POSTER}",
+	"{INS->UNKNOWN_TITLE}",
+	"{INS->REQUIRE_AUTH}",
+	"{INS->DISPLAYURL_OVERRIDE}",
+	"{INS->NOUNS}",
+	"{INS->ADJECTIVES}"
+);
+
+// To protect already upgraded configs, those values are also checked, if existing.
+$UPDATE = array(
+	parseOption($config['site_name']) ,
+	parseOption($config['db_hostname']) ,
+	parseOption($config['db_database']) ,
+	parseOption($config['db_username']) ,
+	parseOption($config['db_password']) ,
+	parseOption($config['db_prefix']) ,
+	parseOption($config['theme']) ,
+	parseOption($config['combine_assets']) ,
+	parseOption($config['cron_key']) ,
+	"\$config['url_shortening_use'] = " . (isset($config['url_shortening_use']) ? parseOption($config['url_shortening_use']) : "'off'") . ';' . PHP_EOL . "\$config['random_url_engines'] = " . ((isset($config['random_url_engines'])) ? parseOption($config['random_url_engines']) : "'googl,bitly'") . "; // Used only in random mode, read comment above for more info" . PHP_EOL,
+	parseOption($config['yourls_url']) ,
+	parseOption($config['yourls_signature']) ,
+	parseOption($config['gwgd_url']) ,
+	parseOption($config['shorturl_selected']) ,
+	"// goo.gl API key" . PHP_EOL . "\$config['googl_url_api'] = " . (isset($config['googl_url_api']) ? parseOption($config['googl_url_api']) : "''") . ';' . PHP_EOL . "// Bit.ly API key" . PHP_EOL . "\$config['bitly_url_api'] = " . (isset($config['bitly_url_api']) ? parseOption($config['bitly_url_api']) : "''") . ";" . PHP_EOL,
+	parseOption($config['backup_user']) ,
+	parseOption($config['backup_pass']) ,
+	parseOption($config['per_page']) ,
+	parseOption($config['apikey']) ,
+	parseOption($config['private_only']) ,
+	parseOption($config['enable_captcha']) ,
+	parseOption($config['recaptcha_publickey']) ,
+	parseOption($config['recaptcha_privatekey']) ,
+	parseOption($config['disable_api']) ,
+	parseOption($config['disable_keep_forever']) ,
+	parseOption($config['blocked_words']) ,
+	parseOption($config['disable_shorturl']) ,
+	parseOption($config['disallow_search_engines']) ,
+	parseOption($config['spamadmin_user']) ,
+	parseOption($config['spamadmin_pass']) ,
+	parseOption($config['default_expiration']) ,
+	parseOption($config['default_language']) ,
+	parseOption($config['unknown_poster']) ,
+	parseOption($config['unknown_title']) ,
+	parseOption($config['require_auth']) ,
+	parseOption($config['displayurl_override']) ,
+	parseOption($config['nouns']) ,
+	parseOption($config['adjectives'])
+);
+$tryTo = @chmod($targetMain, 0777); // Just try, if possible to evade permission errors
+
+$tryTo = @chmod("../upgrade", 0777); // Just try, if possible to evade permission errors
+
+
+if (file_put_contents($targetMain, str_replace($FIND, $UPDATE, $upgradeSchema))) 
+{
+
+	// If succesfull, lock upgrade
+	$loadLock["LOCK"] = true;
+	
+	if (!file_put_contents("lock", serialize(array(
+		"LOCK" => true
+	)))) 
+	{
+		header("location: index.php?status=lockFailed");
+		exit;
+	}
+	header("location: index.php?status=success");
+	exit;
+}
+else
+{
+	header("location: index.php?status=failed");
+	exit;
+}
+header("location: index.php?status=failed");
+exit;

--- a/htdocs/upgrade/upgrade_schema.ugs
+++ b/htdocs/upgrade/upgrade_schema.ugs
@@ -1,0 +1,245 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+/**
+ * Site Name
+ *
+ * The name of your site
+ *
+*/
+$config['site_name'] = {INS->SITE_NAME};
+
+/**
+ * Database connection
+ *
+ * Credentials for your database
+ * The database structure will be created automatically
+ *
+*/
+$config['db_hostname'] = {INS->DB_HOSTNAME};
+$config['db_database'] = {INS->DB_DATABASE};
+$config['db_username'] = {INS->DB_USERNAME};
+$config['db_password'] = {INS->DB_PASSWORD};
+
+/**
+ * Table prefix
+ * Generate table prefix for stikked db, commonly used if the webhoster only has one db.
+ * Use underscore as suffix to easily see the tables.
+ * example: $config['db_prefix'] = 'stikked_';
+ * use $config['db_prefix'] = ''; if you don't want to use table prefix.
+*/
+$config['db_prefix'] = {INS->DB_PREFIX};
+
+/**
+ * Theme
+ *
+ * Which theme to use
+ * Folder name in htdocs/themes/
+ * Currently: default, bootstrap, gabdark, gabdark3, geocities, snowkat, stikkedizr, cleanwhite
+ *
+*/
+$config['theme'] = {INS->THEME};
+
+/**
+ * Language
+ *
+ * New Language settings in application/config/language.php
+ *
+*/
+
+/**
+ * Combine JS & CSS files (recommended)
+ *
+ * htdocs/static/asset/ folder must be writeable
+ *
+*/
+$config['combine_assets'] = {INS->COMBINE_ASSETS};
+
+/**
+ * Key for Cron
+ *
+ * The password required to run the cron job */
+// Example cron: */5 * * * * curl --silent http://yoursite.com/cron/[key]
+//
+//
+$config['cron_key'] = {INS->CRON_KEY};
+
+/**
+ * url shortener config
+ *
+ * url_shortening_use:
+ *    - Enables specific url shortening engine or disables them all
+ *    - Valid values:
+ *           @string yourls
+ *           @string gwgd
+ *           @string googl
+ *           @string bitly 
+ *           @string random - Randomly chose any of upper API-s !WARNING! May be slow! For maximum performanse, it's recommended to either set all API keys or use random_url_engines to list working engines.
+ *           @string none - same as off
+ * 
+ * random_url_engines:
+ *    - This variable sets list of APIs to be considered for usage if url_shortening_use is set to 'random'
+ *      To consider all API-s, either leave it empty (as empty array or string) or type all apis available (yourls,gwgd,googl,bitly)
+ *      be aware that considering all the APIs is not recommended because program will test them all, and that affects speed.
+ *      This will greatly improve performance of 'random' mode if listed are only valid, filled APIs.
+ *      Accepted inputs:
+ *           @array array('use this', 'and this', 'and this of course')
+ *           @string 'use this,and this,and this of course'
+ *      - If input is @string it must be comma delimited, otherwise will be ignored.
+ *      - Script will accept minimum of 2 APIs, ignored otherwise
+ *      - Only alphanumeric characters and "." are allowed. Everything else is filtered out.
+ * 
+ * -------------------------------------------------------------------------------------------------------------
+ * yourls_url: Your own instance of yourls URL-shortener (Download: http://yourls.org/)
+ * Example: http://example.com/yourls/
+ *
+ * yourls_signature: Your signature, used to authenticate API requests.
+ * You can find your signature under http://your-yourls-installation.com/admin/tools.php
+ *
+ * gwgd_url: Your own instance of the gw.gd URL-shortener (Download: https://github.com/neofutur/gwgd)
+ * Default: http://gw.gd/
+ *
+ * googl_url_api: URL shortening service provided by Google Inc. (API: http://code.google.com/apis/console/) 
+ * Usage: Your API key
+ * 
+ * bitly_url_api: Famous URL shortening service (API: http://dev.bitly.com/get_started.html)
+ * Usage: Your API key
+ * 
+**/
+{INS->URL_SHORTENING_NEW#1}
+
+// Yourls
+$config['yourls_url'] = {INS->YOURLS_URL};
+$config['yourls_signature'] = {INS->YOURLS_SIGNATURE};
+
+// gwgd_url
+$config['gwgd_url'] = {INS->GWGD_URL};
+$config['shorturl_selected'] = {INS->SHORTURL_SELECTED};
+
+{INS->URL_SHORTENING_NEW#2}
+
+
+/**
+ * Credentials for the backup URL
+ *
+ * Basic auth user & pass for the backup URL, accessible via http://yoursite.com/backup
+ *
+**/
+$config['backup_user'] = {INS->BACKUP_USER};
+$config['backup_pass'] = {INS->BACKUP_PASS};
+
+/**
+ * Pastes Per Page
+ *
+ * Number of pastes per page, on the recent pastes listings.
+ *
+**/
+$config['per_page'] = {INS->PER_PAGE};
+
+/**
+ * API key
+ *
+ * Require a key to interact with the API.
+ * Append to all API requests: ?apikey=[yourkey]
+ *
+**/
+$config['apikey'] = {INS->APIKEY};
+
+/**
+ * Anti spam
+ *
+ * private_only: No recent pastes will be displayed.
+ * enable_captcha: Users must enter a captcha to post.
+ * recaptcha_publickey & recaptcha_privatekey: If filled, reCaptcha will be used (get a key from https://www.google.com/recaptcha/admin/create)
+ * disable_api: Don't allow pasting via API (because we can't use a captcha there...)
+ * disable_keep_forever: Don't allow pasting without expiration
+ * blocked_words: Comma separated list, e.g. '.es.tl, mycraft.com, yourbadword'
+ * disable_shorturl: "Create Shorturl" option will be disabled
+ * disallow_search_engines: displays a robots.txt that forbids indexing
+ *
+**/
+$config['private_only'] = {INS->PRIVATE_ONLY};
+$config['enable_captcha'] = {INS->ENABLE_CAPTCHA};
+$config['recaptcha_publickey'] = {INS->PUBLICKEY};
+$config['recaptcha_privatekey'] = {INS->PRIVATEKEY};
+$config['disable_api'] = {INS->DISABLEAPI};
+$config['disable_keep_forever'] = {INS->DISABLEKEEPFOREVER};
+$config['blocked_words'] = {INS->BLOCKEDWORDS};
+$config['disable_shorturl'] = {INS->DISABLE_SHORTURL};
+$config['disallow_search_engines'] = {INS->DISALLOW_SEARCH_ENGINES};
+
+//spamadmin: accessible via /spamadmin (only active when user + pass is set)
+$config['spamadmin_user'] = {INS->SPAMADMIN_USER};
+$config['spamadmin_pass'] = {INS->SPAMADMIN_PASS};
+
+/**
+ * Default paste expiration time (minutes)
+ *
+ * Possible values:
+ *  burn (burn on reading)
+ *  5 (5 minutes)
+ *  60 (1 hour)
+ *  1440 (1 day)
+ *  10080 (1 week)
+ *  40320 (1 month)
+ *  483840 (1 year)
+ *  0 (keep forever)
+**/
+$config['default_expiration'] = {INS->DEFAULT_EXPIRATION};
+
+/**
+ * Default language
+ *
+ * Preselected language. See application/config/geshi_languages.php for valid values (array keys)
+ *
+**/
+$config['default_language'] = {INS->DEFAULT_LANGUAGE};
+
+/**
+ * Name for anonymous poster
+ *
+ * What name is to be set for anonymous posters
+ * DO NOT SET BLANK
+ * Set to random for a random paste to be generated
+ * NOTE: if changed only pastes from then on will be updated.
+ *
+**/
+$config['unknown_poster'] = {INS->UNKNOWN_POSTER};
+
+/**
+ * Name for untitled pastes
+ *
+ * What name is to be set for untitled pastes.
+ * DO NOT SET BLANK
+ * NOTE: if changed only pastes from then on will be updated.
+**/
+$config['unknown_title'] = {INS->UNKNOWN_TITLE};
+
+/**
+ * To require LDAP authentication or not.
+ *
+ * Weather to require LDAP authenticaiton or not.
+ * Set to either 'true' to require authentication or 'false' not to.
+ * NOTE: if changed, set LDAP settings in auth_ldap.php
+**/ 
+$config['require_auth'] = {INS->REQUIRE_AUTH};
+ 
+/**
+ * Override the displayed URL
+ *
+ * Display this URL in a paste's detail view instead of the main URL - e.g. if you use mod_rewrite
+ * Variable $id: the paste_id
+ * Example: 'http://example.com/$id'
+ *
+**/
+$config['displayurl_override'] = {INS->DISPLAYURL_OVERRIDE};
+
+/**
+ *
+ *
+ *  Words used for when unknown_poster is set to random
+ *
+ *
+**/
+$config['nouns'] = {INS->NOUNS};
+
+$config['adjectives'] = {INS->ADJECTIVES};


### PR DESCRIPTION
Managed to damage fork, don't ask how,, so I had to re-fork, commit and now reopen request. All code is up to date with current state of your repository. (2015/08/19 08:01PM)


Support for both mentioned API-s added, options in stikked.php.dist as well.
For users migrating from <0.9.2 (or whatever this version will be - decide your self and add appropriate changes), there is upgrade script which will prepare their application/config/stikked.php for new features, otherwise Stikked will fall back to legacy mode and they will be able to use only standard (yourls, gw.gd) API-s (until upgrade isn't done).
Upgrade script is safe to use, and will keep all options, however will ignore any custom code added by user. 
After successful upgrade, if there are write permission, script will add lock file and upgrade will be locked until mentioned file is removed.

Except Goog.gl and Bit.ly there is also "random" option which will make Stikked to chose randomly any properly set API and use it's URL shortening powers. This option may be a bit slow, so it's recommended that all API-s are filled up correctly. 
In latest commit there are possibility to chose which APIs will be considered in random mode.