### PR TITLE
Fix issue with RAM consumption during expiry maintenance

### DIFF
--- a/htdocs/application/models/Pastes.php
+++ b/htdocs/application/models/Pastes.php
@@ -901,6 +901,7 @@ class Pastes extends CI_Model
 	function cron() 
 	{
 		$now = now();
+		$this->db->select('pid,expire');
 		$this->db->where('toexpire', '1');
 		$query = $this->db->get('pastes');
 		foreach ($query->result_array() as $row) 


### PR DESCRIPTION
Currently, expiry is done with a SELECT *, pulling in paste bodies.

For busy installations, this can consume large amounts of RAM, especially with large pastes since it pulls paste bodies into RAM.

Modify cron to only select specific columns we need.