### PR TITLE
Add support for nginx reverse proxy

### DIFF
--- a/htdocs/application/controllers/Main.php
+++ b/htdocs/application/controllers/Main.php
@@ -736,10 +736,15 @@ class Main extends CI_Controller
 			die("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
 		}
 		
-		if ($this->input->post('g-recaptcha-response')) 
+		if ($this->input->post('g-recaptcha-response'))
 		{
 			$pk = $this->recaptcha_privatekey;
 			$ra = $_SERVER['REMOTE_ADDR'];
+
+			// handle PHP being used in a proxy setup
+			if (isset($_SERVER['HTTP_X_REAL_IP']))
+				$ra = $_SERVER['HTTP_X_REAL_IP'];
+
 			$rf = trim($this->input->post('g-recaptcha-response'));
 			$url = "https://www.google.com/recaptcha/api/siteverify?secret=" . $pk . "&response;=" . $rf . "&remoteip;=" . $ra;
 			$response = $this->curl->simple_get($url);

--- a/htdocs/application/libraries/Auth_ldap.php
+++ b/htdocs/application/libraries/Auth_ldap.php
@@ -194,7 +194,13 @@ class Auth_Ldap {
         
         if(!isset($entries[0])){
             //User either does not exist or has no permissions
-            $this->_audit("Failed login attempt: ".$username." from ".$_SERVER['REMOTE_ADDR']);
+            $ra = $_SERVER['REMOTE_ADDR'];
+
+            // handle PHP being used in a proxy setup
+            if (isset($_SERVER['HTTP_X_REAL_IP']))
+                $ra = $_SERVER['HTTP_X_REAL_IP'];
+
+            $this->_audit("Failed login attempt: ".$username." from ".$ra);
             return FALSE;
         }
         
@@ -203,7 +209,13 @@ class Auth_Ldap {
         // Now actually try to bind as the user
         $bind = ldap_bind($this->ldapconn, $binddn, $password);
         if(! $bind) {
-            $this->_audit("Failed login attempt: ".$username." from ".$_SERVER['REMOTE_ADDR']);
+            $ra = $_SERVER['REMOTE_ADDR'];
+
+            // handle PHP being used in a proxy setup
+            if (isset($_SERVER['HTTP_X_REAL_IP']))
+                $ra = $_SERVER['HTTP_X_REAL_IP'];
+
+            $this->_audit("Failed login attempt: ".$username." from ".$ra);
             return FALSE;
         }
         $cn = $entries[0]['cn'][0];

--- a/htdocs/system/core/Input.php
+++ b/htdocs/system/core/Input.php
@@ -427,6 +427,9 @@ class CI_Input {
 		}
 
 		$this->ip_address = $this->server('REMOTE_ADDR');
+		// Set real IP if proxy is used
+		if (isset($this->server('HTTP_X_REAL_IP')))
+			$this->ip_address = $this->server('HTTP_X_REAL_IP');
 
 		if ($proxy_ips)
 		{

--- a/htdocs/system/libraries/Profiler.php
+++ b/htdocs/system/libraries/Profiler.php
@@ -463,7 +463,7 @@ class CI_Profiler {
 			.'&nbsp;&nbsp;(<span style="cursor: pointer;" onclick="var s=document.getElementById(\'ci_profiler_httpheaders_table\').style;s.display=s.display==\'none\'?\'\':\'none\';this.innerHTML=this.innerHTML==\''.$this->CI->lang->line('profiler_section_show').'\'?\''.$this->CI->lang->line('profiler_section_hide').'\':\''.$this->CI->lang->line('profiler_section_show').'\';">'.$this->CI->lang->line('profiler_section_show')."</span>)</legend>\n\n\n"
 			.'<table style="width:100%;display:none;" id="ci_profiler_httpheaders_table">'."\n";
 
-		foreach (array('HTTP_ACCEPT', 'HTTP_USER_AGENT', 'HTTP_CONNECTION', 'SERVER_PORT', 'SERVER_NAME', 'REMOTE_ADDR', 'SERVER_SOFTWARE', 'HTTP_ACCEPT_LANGUAGE', 'SCRIPT_NAME', 'REQUEST_METHOD',' HTTP_HOST', 'REMOTE_HOST', 'CONTENT_TYPE', 'SERVER_PROTOCOL', 'QUERY_STRING', 'HTTP_ACCEPT_ENCODING', 'HTTP_X_FORWARDED_FOR', 'HTTP_DNT') as $header)
+		foreach (array('HTTP_ACCEPT', 'HTTP_USER_AGENT', 'HTTP_CONNECTION', 'SERVER_PORT', 'SERVER_NAME', 'REMOTE_ADDR', 'SERVER_SOFTWARE', 'HTTP_ACCEPT_LANGUAGE', 'SCRIPT_NAME', 'REQUEST_METHOD',' HTTP_HOST', 'REMOTE_HOST', 'CONTENT_TYPE', 'SERVER_PROTOCOL', 'QUERY_STRING', 'HTTP_ACCEPT_ENCODING', 'HTTP_X_REAL_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_DNT') as $header)
 		{
 			$val = isset($_SERVER[$header]) ? $_SERVER[$header] : '';
 			$output .= '<tr><td style="vertical-align:top;width:50%;padding:5px;color:#900;background-color:#ddd;">'

--- a/htdocs/system/libraries/Session/drivers/Session_database_driver.php
+++ b/htdocs/system/libraries/Session/drivers/Session_database_driver.php
@@ -154,7 +154,11 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 
 			if ($this->_config['match_ip'])
 			{
-				$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
+				$ra = $_SERVER['REMOTE_ADDR'];
+				if(isset($_SERVER['HTTP_X_REAL_IP']))
+					$ra = $_SERVER['HTTP_X_REAL_IP'];
+
+				$this->_db->where('ip_address', $ra);
 			}
 
 			if (($result = $this->_db->get()->row()) === NULL)
@@ -210,9 +214,13 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 
 		if ($this->_row_exists === FALSE)
 		{
+			$ra = $_SERVER['REMOTE_ADDR'];
+			if(isset($_SERVER['HTTP_X_REAL_IP']))
+				$ra = $_SERVER['HTTP_X_REAL_IP'];
+
 			$insert_data = array(
 				'id' => $session_id,
-				'ip_address' => $_SERVER['REMOTE_ADDR'],
+				'ip_address' => $ra,
 				'timestamp' => time(),
 				'data' => ($this->_platform === 'postgre' ? base64_encode($session_data) : $session_data)
 			);
@@ -229,7 +237,11 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		$this->_db->where('id', $session_id);
 		if ($this->_config['match_ip'])
 		{
-			$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
+			$ra = $_SERVER['REMOTE_ADDR'];
+			if(isset($_SERVER['HTTP_X_REAL_IP']))
+				$ra = $_SERVER['HTTP_X_REAL_IP'];
+
+			$this->_db->where('ip_address', $ra);
 		}
 
 		$update_data = array('timestamp' => time());
@@ -282,7 +294,11 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 			$this->_db->where('id', $session_id);
 			if ($this->_config['match_ip'])
 			{
-				$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
+				$ra = $_SERVER['REMOTE_ADDR'];
+				if(isset($_SERVER['HTTP_X_REAL_IP']))
+					$ra = $_SERVER['HTTP_X_REAL_IP'];
+
+				$this->_db->where('ip_address', $ra);
 			}
 
 			return $this->_db->delete($this->_config['save_path'])
@@ -322,7 +338,11 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	{
 		if ($this->_platform === 'mysql')
 		{
-			$arg = $session_id.($this->_config['match_ip'] ? '_'.$_SERVER['REMOTE_ADDR'] : '');
+			$ra = $_SERVER['REMOTE_ADDR'];
+			if(isset($_SERVER['HTTP_X_REAL_IP']))
+				$ra = $_SERVER['HTTP_X_REAL_IP'];
+
+			$arg = $session_id.($this->_config['match_ip'] ? '_'.$ra : '');
 			if ($this->_db->query("SELECT GET_LOCK('".$arg."', 300) AS ci_session_lock")->row()->ci_session_lock)
 			{
 				$this->_lock = $arg;
@@ -333,7 +353,11 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		}
 		elseif ($this->_platform === 'postgre')
 		{
-			$arg = "hashtext('".$session_id."')".($this->_config['match_ip'] ? ", hashtext('".$_SERVER['REMOTE_ADDR']."')" : '');
+			$ra = $_SERVER['REMOTE_ADDR'];
+                        if(isset($_SERVER['HTTP_X_REAL_IP']))
+                                $ra = $_SERVER['HTTP_X_REAL_IP'];
+
+			$arg = "hashtext('".$session_id."')".($this->_config['match_ip'] ? ", hashtext('".$ra."')" : '');
 			if ($this->_db->simple_query('SELECT pg_advisory_lock('.$arg.')'))
 			{
 				$this->_lock = $arg;

--- a/htdocs/system/libraries/Session/drivers/Session_files_driver.php
+++ b/htdocs/system/libraries/Session/drivers/Session_files_driver.php
@@ -125,9 +125,14 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 		}
 
 		$this->_config['save_path'] = $save_path;
+
+		$ra = $_SERVER['REMOTE_ADDR'];
+		if(isset($_SERVER['HTTP_X_REAL_IP']))
+			$ra = $_SERVER['HTTP_X_REAL_IP'];
+
 		$this->_file_path = $this->_config['save_path'].DIRECTORY_SEPARATOR
 			.$name // we'll use the session cookie name as a prefix to avoid collisions
-			.($this->_config['match_ip'] ? md5($_SERVER['REMOTE_ADDR']) : '');
+			.($this->_config['match_ip'] ? md5($ra) : '');
 
 		return TRUE;
 	}

--- a/htdocs/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/htdocs/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -88,7 +88,11 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 
 		if ($this->_config['match_ip'] === TRUE)
 		{
-			$this->_key_prefix .= $_SERVER['REMOTE_ADDR'].':';
+			$ra = $_SERVER['REMOTE_ADDR'];
+                        if(isset($_SERVER['HTTP_X_REAL_IP']))
+                                $ra = $_SERVER['HTTP_X_REAL_IP'];
+
+			$this->_key_prefix .= $ra.':';
 		}
 	}
 

--- a/htdocs/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/htdocs/system/libraries/Session/drivers/Session_redis_driver.php
@@ -105,7 +105,11 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 
 		if ($this->_config['match_ip'] === TRUE)
 		{
-			$this->_key_prefix .= $_SERVER['REMOTE_ADDR'].':';
+			$ra = $_SERVER['REMOTE_ADDR'];
+                        if(isset($_SERVER['HTTP_X_REAL_IP']))
+                                $ra = $_SERVER['HTTP_X_REAL_IP'];
+
+			$this->_key_prefix .= $ra.':';
 		}
 	}
 


### PR DESCRIPTION
If nginx is used in a reverse proxy, REMOTE_ADDR will be set to the
local IP address which is useless for spam detection. The solution
to this is to use proxy_set_header X-Real-IP ; in nginx

to use that header, all of the code needed to set remote address to
['REMOTE_ADDR'] initally and then, if it was set, use
HTTP_X_REAL_IP to set the true IP.

This allows admins to see where spam is truly coming from once again.

For more info see the following link:
https://easyengine.io/tutorials/nginx/forwarding-visitors-real-ip/

Signed-off-by: Simon Sickle <simon@simonsickle.com>