### PR TITLE
fixed footer fot stikkedizr theme

### DIFF
--- a/htdocs/themes/stikkedizr/views/about.php
+++ b/htdocs/themes/stikkedizr/views/about.php
@@ -25,4 +25,4 @@
 	</div>
 </div>
 
-<?php $this->load->view("stikkedizr/footer");?>
+<?php $this->load->view("defaults/footer");?>

--- a/htdocs/themes/stikkedizr/views/api_help.php
+++ b/htdocs/themes/stikkedizr/views/api_help.php
@@ -80,4 +80,4 @@
 	</div>
 </div>
 
-<?php $this->load->view("stikkedizr/footer");?>
+<?php $this->load->view("defaults/footer");?>

--- a/htdocs/themes/stikkedizr/views/list.php
+++ b/htdocs/themes/stikkedizr/views/list.php
@@ -39,4 +39,4 @@
 		<?php }?>
 <?php echo $pages; ?>
 <div class="spacer"></div>
-<?php $this->load->view('stikkedizr/footer');?>
+<?php $this->load->view('defaults/footer');?>

--- a/htdocs/themes/stikkedizr/views/trends.php
+++ b/htdocs/themes/stikkedizr/views/trends.php
@@ -37,4 +37,4 @@
 		<?php }?>
 <?php echo $pages; ?>
 <div class="spacer"></div>
-<?php $this->load->view('stikkedizr/footer');?>
+<?php $this->load->view('defaults/footer');?>


### PR DESCRIPTION
seems like there is a mistake when loading the footer in some pages of the stikkedizr theme.

it should read `$this->load->view('defaults/footer');` rather than `$this->load->view('stikkedizr/footer');`