### PR TITLE
use __construct in cssmin library

### DIFF
--- a/htdocs/application/libraries/Cssmin.php
+++ b/htdocs/application/libraries/Cssmin.php
@@ -61,7 +61,7 @@
  
  class cssmin {
  	
- 	public function cssmin()
+ 	public function __construct()
  	{
  		log_message('debug', 'CSSMin library initialized.');
  	}


### PR DESCRIPTION
This will avoid a PHP error stating that methods with the same name as their class will not be treated as constructors in future versions of PHP.