### PR TITLE
Fix language.php small mistakes of chinese-simplified.

### DIFF
--- a/htdocs/application/config/language.php
+++ b/htdocs/application/config/language.php
@@ -95,10 +95,10 @@ $config['supported_languages'] = array(
         'ckeditor'    => NULL
     ),
     'cn' => array(
-        'name'        => '繁體中文',
+        'name'        => '简体中文',
         'folder'      => 'chinese-simplified',
         'direction'   => 'ltr',
-        'codes'       => array('cht', 'chinese-simplified', 'zh-CN'),
+        'codes'       => array('chs', 'chinese-simplified', 'zh-CN'),
         'ckeditor'    => NULL
     ),
     'zh' => array(


### PR DESCRIPTION
Dear Stikked Team,
Hello.
I am a Chinese Student and Stikked user. Recently, I find a small mistake in htdocs\application\config\language.php
'chinese-simplified' means '简体中文' while 'chinese-traditional' means '繁體中文', and in language.php both chinese-simplified and chinese-traditional are trans to '繁體中文', and this is obviously a mistake.  And these is another 'cht' mistake in the language 'cn' part.
Although this mistake seemingly NOT have bad effect in application's function, but I think it should be fixed.

Sincerely,
YangJun