### PR TITLE
Security + Bug Fix

### DIFF
--- a/htdocs/application/controllers/Api.php
+++ b/htdocs/application/controllers/Api.php
@@ -26,6 +26,13 @@ class Api extends Main
 		{
 			die("The API has been disabled\n");
 		}
+
+        // if ldap is configured and no api token is configured, fail the request
+        if ((config_item('require_auth') == true) && (config_item('apikey') == ''))
+        {
+             die("API key not configured");
+        }
+
 	}
 	
 	function index() 

--- a/htdocs/application/controllers/Auth.php
+++ b/htdocs/application/controllers/Auth.php
@@ -120,7 +120,7 @@ class Auth extends CI_Controller
 	public 
 	function alpha_dash_dot($str) 
 	{
-		return (!preg_match("/^([-a-z0-9_-\.])+$/i", $str)) ? FALSE : TRUE;
+		return (!preg_match("/^([-a-z0-9_\-\.])+$/i", $str)) ? FALSE : TRUE;
 	}
 }
 ?>


### PR DESCRIPTION
I added logic to the API to deny all API requests, if LDAP is configured and an API token is not configured. I figure if you are requiring LDAP, you do not want your pastes to be exposed to unauthenticated users. 

I also fixed a regex bug that was causing issues when using ldap (PHP error: `preg_match(): Compilation failed: range out of order in character class`). 