### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.0-apache
+COPY htdocs /var/www/html
+COPY htdocs/application/config/stikked.php.dist /var/www/html/application/config/stikked.php
+COPY replace-envvars.sh /bin/
+COPY docker-php-entrypoint /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-php-entrypoint
+
+EXPOSE 80
+RUN a2enmod rewrite
+RUN docker-php-ext-install mysqli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  db:
+    image: mysql:latest
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_DATABASE: stikked
+      MYSQL_USER: stikked
+      MYSQL_PASSWORD: stikked
+
+  stikked:
+    depends_on:
+      - db
+    image: stikked
+    env_file:
+      stikked-envvars.txt
+    ports:
+      - 80:80
+
+volumes:
+  db_data:

--- a/docker-php-entrypoint
+++ b/docker-php-entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# custom script to overwrite stikked config variables
+bash /bin/replace-envvars.sh
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php "$@"
+fi
+
+exec "$@"

--- a/replace-envvars.sh
+++ b/replace-envvars.sh
@@ -1,0 +1,7 @@
+sed -i "s/\['site_name'\].*/['site_name'] = '$SITENAME';/" /var/www/html/application/config/stikked.php
+sed -i "s/\['base_url'\].*/['base_url'] = '$BASEURL';/" /var/www/html/application/config/stikked.php
+sed -i "s/\['db_hostname'\].*/['db_hostname'] = '$DBHOST';/" /var/www/html/application/config/stikked.php
+sed -i "s/\['db_database'\].*/['db_database'] = '$DBNAME';/" /var/www/html/application/config/stikked.php
+sed -i "s/\['db_username'\].*/['db_username'] = '$DBUSER';/" /var/www/html/application/config/stikked.php
+sed -i "s/\['db_password'\].*/['db_password'] = '$DBPASS';/" /var/www/html/application/config/stikked.php
+sed -i "s/\['enable_captcha'\].*/['enable_captcha'] = '$CAPTHCA';/" /var/www/html/application/config/stikked.php

--- a/stikked-envvars.txt
+++ b/stikked-envvars.txt
@@ -1,0 +1,7 @@
+SITENAME=Stikked
+BASEURL=http:\/\/stikked.local\/
+DBHOST=db
+DBNAME=stikked
+DBUSER=stikked
+DBPASS=stikked
+CAPTCHA=false


### PR DESCRIPTION
I have added support to run Stikked in a docker container. 

How to run it:
1) docker build -t stikked .
2) docker-compose up -d

This automatically creates a database with passwords that are configurable by environment variables. 

NOTE: This sets the captcha to false and requires port 80 to be accessible on the host machine. Also, a host entry of `127.0.0.1 stikked.local` will fix the base_url issues. 

I can add more support, if this is something that @claudehohl you feel is a nice feature. 