### PR TITLE
fixed CSRF issue

### DIFF
--- a/htdocs/themes/bootstrap/views/defaults/paste_form.php
+++ b/htdocs/themes/bootstrap/views/defaults/paste_form.php
@@ -125,6 +125,14 @@
 					<i class="icon-pencil icon-white"></i>
 					<?php echo lang('paste_create'); ?>
 				</button>
+				<?php
+				if ($this->config->item('csrf_protection') === TRUE)
+				{
+					if(isset($_COOKIE[$this->config->item('csrf_cookie_name')])) {
+						echo '<input type="hidden" name="'.$this->config->item('csrf_token_name').'" value="'.html_escape($_COOKIE[$this->config->item('csrf_cookie_name')]).'" style="display:none;" />'."\n";
+					}
+				}
+				?>
 			</div>
 		</form>
 	</div>

--- a/htdocs/themes/cleanwhite/views/defaults/paste_form.php
+++ b/htdocs/themes/cleanwhite/views/defaults/paste_form.php
@@ -133,5 +133,13 @@
 
 		<div><button type="submit" value="submit" name="submit"><?php echo lang('paste_create'); ?></button></div>
 		<div class="spacer"></div>
+		<?php
+		if ($this->config->item('csrf_protection') === TRUE)
+		{
+			if(isset($_COOKIE[$this->config->item('csrf_cookie_name')])) {
+				echo '<input type="hidden" name="'.$this->config->item('csrf_token_name').'" value="'.html_escape($_COOKIE[$this->config->item('csrf_cookie_name')]).'" style="display:none;" />'."\n";
+			}
+		}
+		?>
 	</form>
 </div>

--- a/htdocs/themes/default/views/defaults/paste_form.php
+++ b/htdocs/themes/default/views/defaults/paste_form.php
@@ -131,6 +131,15 @@
 ?>
 
 		<div class="clear"><button type="submit" value="submit" name="submit"><?php echo lang('paste_create'); ?></button></div>
+		<?php
+		if ($this->config->item('csrf_protection') === TRUE)
+		{
+			if(isset($_COOKIE[$this->config->item('csrf_cookie_name')])) {
+				echo '<input type="hidden" name="'.$this->config->item('csrf_token_name').'" value="'.html_escape($_COOKIE[$this->config->item('csrf_cookie_name')]).'" style="display:none;" />'."\n";
+			}
+		}
+		?>
 		<div class="spacer"></div>
+
 	</form>
 </div>

--- a/htdocs/themes/geocities/views/defaults/paste_form.php
+++ b/htdocs/themes/geocities/views/defaults/paste_form.php
@@ -132,6 +132,14 @@
 					<?php echo lang('paste_create'); ?>
 				</button>
 			</div>
+			<?php
+			if ($this->config->item('csrf_protection') === TRUE)
+			{
+				if(isset($_COOKIE[$this->config->item('csrf_cookie_name')])) {
+					echo '<input type="hidden" name="'.$this->config->item('csrf_token_name').'" value="'.html_escape($_COOKIE[$this->config->item('csrf_cookie_name')]).'" style="display:none;" />'."\n";
+				}
+			}
+			?>
 		</form>
 	</div>
 </div>

--- a/htdocs/themes/i386/views/defaults/paste_form.php
+++ b/htdocs/themes/i386/views/defaults/paste_form.php
@@ -134,6 +134,14 @@
 					<i class="icon-pencil icon-white"></i>
 					<?php echo lang('paste_create'); ?>
 				</button>
+				<?php
+				if ($this->config->item('csrf_protection') === TRUE)
+				{
+					if(isset($_COOKIE[$this->config->item('csrf_cookie_name')])) {
+						echo '<input type="hidden" name="'.$this->config->item('csrf_token_name').'" value="'.html_escape($_COOKIE[$this->config->item('csrf_cookie_name')]).'" style="display:none;" />'."\n";
+					}
+				}
+				?>
 			</div>
 		</form>
 	</div>

--- a/htdocs/themes/stikkedizr/views/defaults/paste_form.php
+++ b/htdocs/themes/stikkedizr/views/defaults/paste_form.php
@@ -134,6 +134,14 @@
 					<?php echo lang('paste_create'); ?>
 				</button>
 			</div>
+			<?php
+			if ($this->config->item('csrf_protection') === TRUE)
+			{
+				if(isset($_COOKIE[$this->config->item('csrf_cookie_name')])) {
+					echo '<input type="hidden" name="'.$this->config->item('csrf_token_name').'" value="'.html_escape($_COOKIE[$this->config->item('csrf_cookie_name')]).'" style="display:none;" />'."\n";
+				}
+			}
+			?>
 		</form>
 	</div>
 </div>


### PR DESCRIPTION
Reported issue: https://github.com/claudehohl/Stikked/issues/435

Cause: The form is not being created by codeigniter's form helper. Therefore, the code that is supposed to insert the hidden CSRF token is not adding it to the form. 

Solution: Add the hidden form field in paste_form.php, if the csrf_protection config option is set to True.  

I am going to come up with a more secure way to implement CSRF for this. However, this will make it work for the time being. 
