### PR TITLE
(REAMDE.md) Remove Android app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Here are some features:
 * Anti-Spam features
 * Themes support
 * Multilanguage support
-* An [Android app](https://play.google.com/store/apps/details?id=org.teamblueridge.pasteitapp)
 * Stikked client with support for client side encryption/decryption: [gostikkit](https://github.com/tcolgate/gostikkit)
 * Another CLI tool requiring only curl program: [pbin](https://github.com/glensc/pbin)
 * And many more. View [this review](http://maketecheasier.com/run-your-own-pastebin-with-stikked/2013/01/11)


### PR DESCRIPTION
Per #441 and teamblueridge/pasteit#7, remove the Android app from the README until a proper successor is written.