### PR TITLE
Remove PHP handler specification from .htaccess

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -35,5 +35,3 @@ FileETag MTime Size
 #AuthName "Backend"
 #AuthUserFile /path/to/.htpasswd #create one with htpasswd -c .htpasswd username
 #Require user username
-
-AddHandler php5-fastcgi .php .php5


### PR DESCRIPTION
Let the server administrator decide the PHP configuration. This can cause an issue where the browser downloads instead of displays, even in very common shared hosting configurations.