### PR TITLE
Missing pick_language hook.

### DIFF
--- a/htdocs/application/config/config.php
+++ b/htdocs/application/config/config.php
@@ -101,7 +101,7 @@ $config['charset'] = 'UTF-8';
 | setting this variable to TRUE (boolean).  See the user guide for details.
 |
 */
-$config['enable_hooks'] = TRUE;
+$config['enable_hooks'] = FALSE;
 
 
 /*

--- a/htdocs/application/config/hooks.php
+++ b/htdocs/application/config/hooks.php
@@ -10,11 +10,7 @@
 |
 */
 
-$hook['pre_controller'][] = array(
-  'function' => 'pick_language',
-  'filename' => 'pick_language.php',
-  'filepath' => 'hooks'
-);
+
 
 /* End of file hooks.php */
 /* Location: ./application/config/hooks.php */


### PR DESCRIPTION
Commit 6da09613 deleted htdocs/application/hooks/pick_language.php to fix #264,
but it did not remove the hook from htdocs/application/config/hooks.php.

This commit reverts htdocs/application/config/hooks.php back to f97a5331 and
disables $config['enable_hooks'] in htdocs/application/config/config.php.
It was introduced in b69c6650.